### PR TITLE
Use singleton JenkinsLocationConfiguration to get root URL

### DIFF
--- a/src/main/java/com/opsgenie/integration/jenkins/OpsGenieNotificationService.java
+++ b/src/main/java/com/opsgenie/integration/jenkins/OpsGenieNotificationService.java
@@ -274,7 +274,7 @@ public class OpsGenieNotificationService {
         requestPayload.put("status", Objects.toString(status));
 
         String url = build.getUrl();
-        requestPayload.put("url", new JenkinsLocationConfiguration().getUrl() + url);
+        requestPayload.put("url", JenkinsLocationConfiguration.get().getUrl() + url);
 
         List<String> tags = splitStringWithComma(alertProperties.getTags());
         requestPayload.put("tags", tags);


### PR DESCRIPTION
Newer versions of Jenkins don't call `JenkinsLocationConfiguration#load()` in the constructor anymore, but we can use the singleton that's already loaded from disk.

More context here: https://issues.jenkins-ci.org/browse/JENKINS-52983?focusedCommentId=347707&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-347707

This change was tested in the script console:

```groovy
println new JenkinsLocationConfiguration().getUrl()
// null
```

```groovy
println JenkinsLocationConfiguration.get().getUrl()
// <the correct url>
```
